### PR TITLE
Added terms and conditions and placeholder privacy policy

### DIFF
--- a/tzundoku/legal/__init__.py
+++ b/tzundoku/legal/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+'''
+This is the tzundoku legal package. It contains information required to generate legal notices, such as the terms and conditions.
+'''
+
+import re
+import os
+import codecs
+
+#ENTITY_DESCRIPTION='''{name of organisation}, a company
+#registered in England and Wales (No. {company number}), whose registered
+#office is at {insert address of registered office here}'''
+
+ENTITY_DESCRIPTION='''Julyan Davey'''
+
+path=os.path.dirname(os.path.abspath(__file__))
+
+privacy=open(os.path.join(path, "privacy.html"), "r").read()
+
+source={}
+for key in ["terms", "privacy"]:
+    file_name=key + ".html"
+    source[key]=codecs.open(os.path.join(path, file_name), "r", encoding='utf-8').read()
+terms=source['terms']
+terms=re.sub("ENTITYDESCRIPTION", ENTITY_DESCRIPTION, terms)
+privacy=source['privacy']

--- a/tzundoku/legal/privacy.html
+++ b/tzundoku/legal/privacy.html
@@ -1,0 +1,2 @@
+<h1 id="privacy-policy">Privacy Policy</h1>
+<p>This policy is under construction.</p>

--- a/tzundoku/legal/privacy.tex
+++ b/tzundoku/legal/privacy.tex
@@ -1,0 +1,3 @@
+\section{Privacy Policy}
+
+This policy is under construction.

--- a/tzundoku/legal/terms.html
+++ b/tzundoku/legal/terms.html
@@ -1,0 +1,63 @@
+<h1 id="terms-and-conditions">Terms and Conditions</h1>
+<h3 id="introduction">Introduction</h3>
+<p>This page sets out the terms on which ENTITYDESCRIPTION (“we”, “us”, “our”) contracts with you for permission to use the <span>name of website</span> web site and any services supplied through it (“this site”). By using this site you agree to be bound by these terms.</p>
+<p>In these terms and conditions the following terms are defined as follows:</p>
+<dl>
+<dt>intellectual property</dt>
+<dd><p>means any rights in patents, registered and unregistered designs, copyright, databases, trade marks, confidential information and all other forms of intellectual property wherever in the world enforceable.</p>
+</dd>
+</dl>
+<p>The nature of this contract is purely permissive. We permit you to use this site as and when then are available. We do not contract to make them available now or at any time or to provide any particular level of service.</p>
+<h3 id="changes-to-terms-and-conditions">Changes to Terms and Conditions</h3>
+<p>As the nature of what we do changes, and as the regulation of the internet evolves, we may need to amend these terms and conditions from time to time by displaying a notice on this page indicating what will be changed (or linking to a separate page where that information will be available) and the date on which the new terms will come into force. We will always give at least 7 days’ notice of any variation and any variation will be binding on you on the first occasion when you use this site after the new terms have come into force.</p>
+<h3 id="use">Use</h3>
+<p>You agree that, in using this site, you will not interfere with the legal rights of any other person or contravene any laws prevailing in any of (i) the jurisdiction(s) to which you are subject; and (ii) England and Wales. Prohibited behavour includes (but is not limited to) any of the following:</p>
+<ol>
+<li><p>infringing the intellectual property rights of any person</p></li>
+<li><p>committing any criminal act</p></li>
+<li><p>invading any individual’s privacy</p></li>
+<li><p>defaming any person</p></li>
+<li><p>behaviour amounting to unlawful harassment</p></li>
+<li><p>any form of denial of service attack</p></li>
+<li><p>any other actionable wrong</p></li>
+<li><p>impersonate any other person, and in particular any other participant of this site or any public figure</p></li>
+</ol>
+<p>In order to protect you, our other participants and yourselves, we have developed a standard of conduct that is strictly enforced. You agree to abide by that standard of conduct which requires that you abide by the following rules concerning the use of this site:</p>
+<ol>
+<li><p>You may not use this site for advertising or marketing of any kind (which includes non-profit organisations) without our permission</p></li>
+<li><p>Only natural, human, persons may use this site. You are forbidden to use cause or allow any automated system to make use of the services available on this site except that we do permit the crawling of this site by the robots of web search engines.</p></li>
+<li><p>No profanities or obscenities of any kind are permitted, whether as part of messages sent through or included in postings to forums on this site. This applies to profanities or obscenities disguised for example with asterisks. If you feel strongly about something, find another way to say it.</p></li>
+<li><p>You may not use this site to transmit pornographic, lewd, obscene, violent, threatening or insulting material or to transmit links to any material of that kind.</p></li>
+<li><p>Do not make personal attacks on other participants. Try to be civil even to those with whom you disagree.</p></li>
+</ol>
+<p>You agree to indemnify us against all loss or damage arising out of any deliberate commission, by you, of any of the prohibited acts listed above, or any deliberate breach of the standard of conduct already described.</p>
+<p>If you wish to complain about any misuse of our site please contact <a href=""><span>abuse@example.com</span></a>.</p>
+<h3 id="disclaimers">Disclaimers</h3>
+<p>Our services are provided “as is” and you make use of these services at your own risk. It would be very foolish of you to rely on our service in a way that could cause you any loss or damage. Do not do so. In particular you should be aware of the following disclaimers:</p>
+<ol>
+<li><p>While we make all reasonable efforts to ensure that our services are continuously available, service interruptions for reasons beyond our control are inevitable. <em>We will accept no liability for any loss you suffer as a result of any interruption to or unavailability or suspension of our services however caused</em>.</p></li>
+<li><p>Similarly, it is virtually impossible to eliminate all bugs from software, however well written. For this reason it is inevitable that our system will occasionally fail to work as expected even if it gives every sign of having done so. <em>We therefore accept no liability for any loss you may suffer as a result of any failure by the site to perform or to have performed in the manner expected of it</em>. You should not rely on the site having worked — for example that it has successfully sent an email —. If you need that level of reliability you should investigate a commercial service.</p></li>
+<li><p>Information posted by users to the site — for example in forums or as comments — is beyond our control and we accept no liability for it whatsoever. Even though we make reasonable efforts to ensure that information that we put on the site is accurate, we draw much of our material from third parties and cannot guarantee its accuracy. You therefore agree that <em>we are not liable for any errors in information we supply on the site.</em></p></li>
+<li><p>It should go without saying that you take responsibility for anything that you write on the site, or the content of any emails that you send using it. While may provide templated information to assit you in writing an email, you should always check that you are happy for it to be sent under your name. Any information you contribute to the site will be visible to the entire world, and any email you send through it may be published by its recipient. People’s reputations have suffered because of poorly thought out emails and contributions to web sites. Only you can make sure that doesn’t happen to you. You agree that <em>we are not responsible for the contents of any email you send, or any material you cause to be displayed on the site.</em></p></li>
+</ol>
+<p>In no event shall we be liable for any direct, indirect, incidental, special, exemplary or consequential damages however caused and arising in anyway out of the use of our services or software.</p>
+<h3 id="privacy">Privacy</h3>
+<p>You consent to our storing and processing the personal information that you have supplied about yourself in accordance with our Privacy Policy.</p>
+<h3 id="suspension-and-termination">Suspension and Termination</h3>
+<p>Either party may terminate this contract at any time by giving written notice to the other. No reason need be given for termination.</p>
+<p>We reserve the right to do any of the following without being required to give you any reason or notice:</p>
+<ol>
+<li><p>suspend or terminate your access to all or any part of the functionality of this site</p></li>
+<li><p>block access to this site from any part of the internet or by any particular means</p></li>
+<li><p>implement a repeat infringer’s policy pursuant to the USC 512(i) or any similar provision</p></li>
+</ol>
+<h3 id="intellectual-property">Intellectual Property</h3>
+<p>All the textual contents of this site are released under the <span>Creative Commons Attribution-Non-Commercial-No Derivative Works 2.0 UK: England &amp; Wales <a href="http://creativecommons.org/licenses/by-nc-nd/2.0/uk/">Licence</a></span>. You may not copy any images, logos or style information (including style sheets).</p>
+<p>You grant us a non-exclusive, worldwide, licence to use any data that you send through or upload to this site.</p>
+<h3 id="general">General</h3>
+<p>This agreement shall be governed by and be construed in accordance with English law. Each party also agrees, to the extent that is permissible by law, to submit to the exclusive jurisdiction of the courts of England and Wales.</p>
+<p>The failure by us to exercise any right under this agreement does not constitute a waiver of that right.</p>
+<p>If any terms of this agreement are held to be void or contrary to law, then they shall be severed from the remainder of the agreement, which shall be read so far as possible without them.</p>
+<p>The Contracts (Rights of Third Parties) Act 1999 does not apply to this agreement.</p>
+<p>Nothing in this agreement constitutes a Partnership between the parties.</p>
+<p>Nothing in these terms and conditions is a restriction of liability for death or personal injury resulting from any fault on our behalf, nor does it lower or restrict your statutory rights.</p>

--- a/tzundoku/legal/terms.tex
+++ b/tzundoku/legal/terms.tex
@@ -1,0 +1,212 @@
+\section{Terms and Conditions}
+
+\subsubsection{Introduction}
+
+This page sets out the terms on which ENTITYDESCRIPTION (``we'', ``us'',
+``our'') contracts with you for permission to use the {name of website}
+web site and any services supplied through it (``this site''). By using
+this site you agree to be bound by these terms.
+
+In these terms and conditions the following terms are defined as
+follows:
+
+\begin{description}
+\item[intellectual property]
+means any rights in patents, registered and unregistered designs,
+copyright, databases, trade marks, confidential information and all
+other forms of intellectual property wherever in the world enforceable.
+\end{description}
+
+The nature of this contract is purely permissive. We permit you to use
+this site as and when then are available. We do not contract to make
+them available now or at any time or to provide any particular level of
+service.
+
+\subsubsection{Changes to Terms and Conditions}
+
+As the nature of what we do changes, and as the regulation of the
+internet evolves, we may need to amend these terms and conditions from
+time to time by displaying a notice on this page indicating what will be
+changed (or linking to a separate page where that information will be
+available) and the date on which the new terms will come into force. We
+will always give at least 7 days' notice of any variation and any
+variation will be binding on you on the first occasion when you use this
+site after the new terms have come into force.
+
+\subsubsection{Use}
+
+You agree that, in using this site, you will not interfere with the
+legal rights of any other person or contravene any laws prevailing in
+any of (i) the jurisdiction(s) to which you are subject; and (ii)
+England and Wales. Prohibited behavour includes (but is not limited to)
+any of the following:
+
+\begin{enumerate}
+\item
+  infringing the intellectual property rights of any person
+\item
+  committing any criminal act
+\item
+  invading any individual's privacy
+\item
+  defaming any person
+\item
+  behaviour amounting to unlawful harassment
+\item
+  any form of denial of service attack
+\item
+  any other actionable wrong
+\item
+  impersonate any other person, and in particular any other participant
+  of this site or any public figure
+\end{enumerate}
+
+In order to protect you, our other participants and yourselves, we have
+developed a standard of conduct that is strictly enforced. You agree to
+abide by that standard of conduct which requires that you abide by the
+following rules concerning the use of this site:
+
+\begin{enumerate}
+
+\item
+  You may not use this site for advertising or marketing of any kind
+  (which includes non-profit organisations) without our permission
+\item
+  Only natural, human, persons may use this site. You are forbidden to
+  use cause or allow any automated system to make use of the services
+  available on this site except that we do permit the crawling of this
+  site by the robots of web search engines.
+\item
+  No profanities or obscenities of any kind are permitted, whether as
+  part of messages sent through or included in postings to forums on
+  this site. This applies to profanities or obscenities disguised for
+  example with asterisks. If you feel strongly about something, find
+  another way to say it.
+\item
+  You may not use this site to transmit pornographic, lewd, obscene,
+  violent, threatening or insulting material or to transmit links to any
+  material of that kind.
+\item
+  Do not make personal attacks on other participants. Try to be civil
+  even to those with whom you disagree.
+\end{enumerate}
+
+You agree to indemnify us against all loss or damage arising out of any
+deliberate commission, by you, of any of the prohibited acts listed
+above, or any deliberate breach of the standard of conduct already
+described.
+
+If you wish to complain about any misuse of our site please contact
+\href{}{{abuse@example.com}}.
+
+\subsubsection{Disclaimers}
+
+Our services are provided ``as is'' and you make use of these services
+at your own risk. It would be very foolish of you to rely on our service
+in a way that could cause you any loss or damage. Do not do so. In
+particular you should be aware of the following disclaimers:
+
+\begin{enumerate}
+
+\item
+  While we make all reasonable efforts to ensure that our services are
+  continuously available, service interruptions for reasons beyond our
+  control are inevitable. \emph{We will accept no liability for any loss
+  you suffer as a result of any interruption to or unavailability or
+  suspension of our services however caused}.
+\item
+  Similarly, it is virtually impossible to eliminate all bugs from
+  software, however well written. For this reason it is inevitable that
+  our system will occasionally fail to work as expected even if it gives
+  every sign of having done so. \emph{We therefore accept no liability
+  for any loss you may suffer as a result of any failure by the site to
+  perform or to have performed in the manner expected of it}. You should
+  not rely on the site having worked --- for example that it has
+  successfully sent an email ---. If you need that level of reliability
+  you should investigate a commercial service.
+\item
+  Information posted by users to the site --- for example in forums or
+  as comments --- is beyond our control and we accept no liability for
+  it whatsoever. Even though we make reasonable efforts to ensure that
+  information that we put on the site is accurate, we draw much of our
+  material from third parties and cannot guarantee its accuracy. You
+  therefore agree that \emph{we are not liable for any errors in
+  information we supply on the site.}
+\item
+  It should go without saying that you take responsibility for anything
+  that you write on the site, or the content of any emails that you send
+  using it. While may provide templated information to assit you in
+  writing an email, you should always check that you are happy for it to
+  be sent under your name. Any information you contribute to the site
+  will be visible to the entire world, and any email you send through it
+  may be published by its recipient. People's reputations have suffered
+  because of poorly thought out emails and contributions to web sites.
+  Only you can make sure that doesn't happen to you. You agree that
+  \emph{we are not responsible for the contents of any email you send,
+  or any material you cause to be displayed on the site.}
+\end{enumerate}
+
+In no event shall we be liable for any direct, indirect, incidental,
+special, exemplary or consequential damages however caused and arising
+in anyway out of the use of our services or software.
+
+\subsubsection{Privacy}
+
+You consent to our storing and processing the personal information that
+you have supplied about yourself in accordance with our Privacy Policy.
+
+\subsubsection{Suspension and Termination}
+
+Either party may terminate this contract at any time by giving written
+notice to the other. No reason need be given for termination.
+
+We reserve the right to do any of the following without being required
+to give you any reason or notice:
+
+\begin{enumerate}
+
+\item
+  suspend or terminate your access to all or any part of the
+  functionality of this site
+\item
+  block access to this site from any part of the internet or by any
+  particular means
+\item
+  implement a repeat infringer's policy pursuant to the USC 512(i) or
+  any similar provision
+\end{enumerate}
+
+\subsubsection{Intellectual Property}
+
+All the textual contents of this site are released under the {Creative
+Commons Attribution-Non-Commercial-No Derivative Works 2.0 UK: England
+\& Wales
+\href{http://creativecommons.org/licenses/by-nc-nd/2.0/uk/}{Licence}}.
+You may not copy any images, logos or style information (including style
+sheets).
+
+You grant us a non-exclusive, worldwide, licence to use any data that
+you send through or upload to this site.
+
+\subsubsection{General}
+
+This agreement shall be governed by and be construed in accordance with
+English law. Each party also agrees, to the extent that is permissible
+by law, to submit to the exclusive jurisdiction of the courts of England
+and Wales.
+
+The failure by us to exercise any right under this agreement does not
+constitute a waiver of that right.
+
+If any terms of this agreement are held to be void or contrary to law,
+then they shall be severed from the remainder of the agreement, which
+shall be read so far as possible without them.
+
+The Contracts (Rights of Third Parties) Act 1999 does not apply to this
+agreement.
+
+Nothing in this agreement constitutes a Partnership between the parties.
+
+Nothing in these terms and conditions is a restriction of liability for
+death or personal injury resulting from any fault on our behalf, nor
+does it lower or restrict your statutory rights.

--- a/tzundoku/templates/layout.html
+++ b/tzundoku/templates/layout.html
@@ -52,7 +52,7 @@
 <!-- FOOTER -->
       <footer>
         <p class="pull-right"><a href="#">Back to top</a></p>
-        <p><a href="#">Privacy</a> &middot; <a href="#">Terms</a></p>
+        <p><a href="privacy">Privacy</a> &middot; <a href="terms">Terms</a></p>
       </footer>
 
     <!-- Bootstrap core JavaScript

--- a/tzundoku/templates/legal.html
+++ b/tzundoku/templates/legal.html
@@ -1,0 +1,5 @@
+{% extends "layout.html" %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+{{ content | safe }}
+{% endblock %}

--- a/tzundoku/views.py
+++ b/tzundoku/views.py
@@ -5,6 +5,8 @@ from .forms import LoginForm
 from .forms import RegistrationForm
 from .models import User
 
+import legal
+
 @tzundoku.route('/')
 @tzundoku.route('/index')
 def index():
@@ -75,3 +77,14 @@ def testdb():
         return 'It Works.'
     else:
         return 'Something is broken'
+
+@tzundoku.route('/terms')
+def terms():
+    return render_template('legal.html',
+                           title="Terms and Conditions",
+                           content=legal.terms)
+@tzundoku.route('/privacy')
+def privacy():
+    return render_template('legal.html',
+                           title="Privacy Policy",
+                           content=legal.privacy)


### PR DESCRIPTION
I've added a terms and conditions page and a placeholder privacy policy. Relies on python 2.x. If that is a problem more thought needs to be given to it.

I've kept the legal stuff (mostly except the template) in a separate sub-module "legal". For the moment I am using latex source and translating to html using pandoc by hand. I will have to note that the html files are not editable.
